### PR TITLE
Create a deep copy instead of a shallow one

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ function App() {
   ])
 
   const handleFormChange = (event, index) => {
-    let data = [...formFields];
+    let data = JSON.parse(JSON.stringify(formFields));
     data[index][event.target.name] = event.target.value;
     setFormFields(data);
   }


### PR DESCRIPTION
Spread operator creates a shallow copy. When you modify an object property in data, it's modified in formFields as well.
JSON will create a deep copy.